### PR TITLE
feat(poland): collect per-tender files via mp-readmodels Search API

### DIFF
--- a/generic_scrapy/filters.py
+++ b/generic_scrapy/filters.py
@@ -28,19 +28,3 @@ class UzbekistanDealTradeFilter:
 
     def accepts(self, item):
         return "deal_id" not in item
-
-
-class PolandContractorFilter:
-    def __init__(self, feed_options):
-        self.feed_options = feed_options
-
-    def accepts(self, item):
-        return "contractorName" in item
-
-
-class PolandNoticeFilter:
-    def __init__(self, feed_options):
-        self.feed_options = feed_options
-
-    def accepts(self, item):
-        return "contractorName" not in item

--- a/generic_scrapy/parsers/poland_announcement.py
+++ b/generic_scrapy/parsers/poland_announcement.py
@@ -1,0 +1,60 @@
+import re
+
+from scrapy import Selector
+
+# Matches an h3 prefix like "1.5.1.) Ulica" or "1.4) Krajowy Numer Identyfikacyjny: REGON 180792174".
+# Group 1: dotted key (e.g. "1.5.1"). Group 2: label. Group 3 (optional): post-colon remainder.
+KEY_RE = re.compile(r"^\s*([0-9]+(?:\.[0-9]+)*)\.?\)\s*(.*?)(?::\s*(.*))?$", re.DOTALL)
+
+
+def _norm(text):
+    return " ".join((text or "").split())
+
+
+def _text(selector):
+    return _norm(" ".join(selector.xpath(".//text()").getall()))
+
+
+def parse_announcement(html):
+    """
+    Parse a Polish BZP announcement (mo-board GetNoticeHtmlBody) into a structured dict.
+
+    Returns ``{"title": str|None, "sections": [...], "_unparsed": [...]}`` where each section
+    is ``{"title": str, "items": [{"key", "label", "value", "extra"}]}``.
+    """
+    sel = Selector(text=html)
+
+    title = _text(sel.xpath("//h1[1]")) or None
+
+    sections = []
+    current = None
+    unparsed = []
+
+    for node in sel.xpath("//h2 | //h3 | //p"):
+        tag = node.root.tag
+        if tag == "h2":
+            if current is not None:
+                sections.append(current)
+            current = {"title": _text(node), "items": []}
+        elif tag == "h3":
+            full_text = _text(node)
+            span_text = _text(node.xpath("span[contains(@class, 'normal')]")) or None
+            match = KEY_RE.match(full_text)
+            if not match:
+                unparsed.append({"section": current["title"] if current else None, "text": full_text})
+                continue
+            key, label, after_colon = match.group(1), _norm(match.group(2)), _norm(match.group(3) or "") or None
+            value = span_text or after_colon
+            item = {"key": key, "label": label, "value": value, "extra": None}
+            (current["items"] if current is not None else unparsed).append(item)
+        elif tag == "p":
+            text = _text(node)
+            if not text or not current or not current["items"]:
+                continue
+            last = current["items"][-1]
+            last["extra"] = f"{last['extra']} {text}" if last["extra"] else text
+
+    if current is not None:
+        sections.append(current)
+
+    return {"title": title, "sections": sections, "_unparsed": unparsed}

--- a/generic_scrapy/spiders/poland.py
+++ b/generic_scrapy/spiders/poland.py
@@ -1,93 +1,141 @@
+import json
+import re
+from pathlib import Path
+from urllib.parse import quote
+
 import scrapy
-from scrapy import Selector
-from scrapy.exceptions import UsageError
 
-from generic_scrapy.base_spiders.export_file_spider import ExportFileSpider
-from generic_scrapy.filters import PolandContractorFilter, PolandNoticeFilter
-from generic_scrapy.util import replace_parameters
+from generic_scrapy.base_spiders.base_spider import BaseSpider
+from generic_scrapy.parsers.poland_announcement import parse_announcement
+
+UNSAFE_FILENAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
-class Poland(ExportFileSpider):
+class Poland(BaseSpider):
+    """
+    Per-procedure file collector for the Polish public-procurement portal (ezamowienia.gov.pl).
+
+    Walks the SearchTenders catalogue (sorted DESC by InitiationDate) and, for each tender, writes:
+      - tender.json         — Search/GetTender response
+      - documents.json      — Search/GetTenderDocuments response (public download URLs)
+      - notice_meta.json    — Board/GetNoticeDetails response (when bzpNumber is set)
+      - announcement.html   — raw Board/GetNoticeHtmlBody body
+      - announcement.json   — announcement.html parsed into structured sections
+      - attachments/<documentId>__<filename> — one file per non-HTML tender attachment
+
+    Output layout: ``<FILES_STORE>/poland/<crawl_directory>/<tenderId>/``. Re-running with the same
+    ``crawl_directory`` skips tenders whose ``tender.json`` is already on disk.
+    """
+
     name = "poland"
 
-    base_url = "https://ezamowienia.gov.pl/mo-board/api/v1/notice"
+    SEARCH_URL = (
+        "https://ezamowienia.gov.pl/mp-readmodels/api/Search/SearchTenders"
+        "?Page={page}&PageSize=100&SortingColumnName=InitiationDate&SortingDirection=DESC"
+    )
+    TENDER_URL = "https://ezamowienia.gov.pl/mp-readmodels/api/Search/GetTender?id={id}"
+    DOCUMENTS_URL = "https://ezamowienia.gov.pl/mp-readmodels/api/Search/GetTenderDocuments?tenderId={id}"
+    DOWNLOAD_URL = "https://ezamowienia.gov.pl/mp-readmodels/api/Tender/DownloadDocument/{tender_id}/{doc_id}"
+    NOTICE_DETAILS_URL = "https://ezamowienia.gov.pl/mo-board/api/v1/Board/GetNoticeDetails?noticeNumber={n}"
+    NOTICE_HTML_URL = "https://ezamowienia.gov.pl/mo-board/api/v1/Board/GetNoticeHtmlBody?noticeNumber={n}"
 
-    notice_types = [
-        "ContractNotice",
-        "TenderResultNotice",
-        "CompetitionNotice",
-        "NoticeUpdateNotice",
-        "AgreementUpdateNotice",
-        "ContractPerformingNotice",
-        "CircumstancesFulfillmentNotice",
-        "SmallContractNotice",
-        "ConcessionNotice",
-        "NoticeUpdateConcession",
-        "ConcessionAgreementNotice",
-        "ConcessionUpdateAgreementNotice",
-    ]
-
-    # ExportFileSpider
-    export_outputs = {
-        "main": {
-            "name": "poland_notices",
-            "formats": ["csv"],
-            "item_filter": PolandNoticeFilter,
-        },
-        "secondary": {
-            "name": "poland_contractors",
-            "formats": ["csv"],
-            "item_filter": PolandContractorFilter,
-        },
-    }
-
-    # BaseSpider
-    date_required = True
-    default_from_date = "2021-01-01T00:00:00"
-
-    @classmethod
-    def from_crawler(cls, crawler, *args, notice_type=None, **kwargs):
-        spider = super().from_crawler(crawler, *args, notice_type=notice_type, **kwargs)
-        if notice_type and spider.notice_type not in spider.notice_types:
-            raise UsageError(f"spider argument `notice_type`: {spider.system!r} not recognized")
-        return spider
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._yielded = 0
 
     async def start(self):
-        for notice_type in self.notice_types:
-            if self.notice_type and notice_type != self.notice_type:
-                continue
-            url = (
-                f"{self.base_url}?NoticeType={notice_type}&PublicationDateFrom={self.from_date}"
-                f"&PublicationDateTo={self.until_date}&PageSize=100"
-            )
-            yield scrapy.Request(url)
+        yield scrapy.Request(self.SEARCH_URL.format(page=1), callback=self.parse_search)
 
-    def parse(self, response, **kwargs):
-        last_object_id = None
-        for item in response.json():
-            html_dict = {}
-            field_name = None
-            last_object_id = item["objectId"]
-            for element in Selector(text=item["htmlBody"]).css(".mb-0"):
-                value = element.xpath("text()").get(default="").strip()
-                # If the element is a field name
-                if "<h3" in element.get():
-                    # If the value of the field is inside as a span element
-                    html_dict[value] = element.xpath("span/text()").get(default="")
-                    # If not, the value is in the subsequents html elements, and we store the field name
-                    if not html_dict[value]:
-                        field_name = value
-                # If the element is not a field name, then it is the value of the previous field name
-                else:
-                    html_dict[field_name] += value
-            full_item = item | html_dict
-            if item["contractors"]:
-                for contractor in item["contractors"]:
-                    if contractor["contractorName"]:
-                        contractor["tenderId"] = item["tenderId"]
-                        yield contractor
-            full_item.pop("htmlBody")
-            full_item.pop("contractors")
-            yield full_item
-        if last_object_id:
-            yield scrapy.Request(replace_parameters(response.request.url, SearchAfter=last_object_id))
+    def parse_search(self, response):
+        pagination = json.loads(response.headers.get("X-Pagination", b"{}").decode("utf-8") or "{}")
+        for summary in response.json():
+            tender_id = summary["objectId"]
+            if (self._tender_dir(tender_id) / "tender.json").exists():
+                continue
+            yield scrapy.Request(
+                self.TENDER_URL.format(id=tender_id),
+                callback=self.parse_tender,
+                cb_kwargs={"tender_id": tender_id},
+            )
+            self._yielded += 1
+            if self.sample and self._yielded >= self.sample:
+                return
+        if pagination.get("HasNext"):
+            yield scrapy.Request(
+                self.SEARCH_URL.format(page=pagination["CurrentPage"] + 1),
+                callback=self.parse_search,
+            )
+
+    def parse_tender(self, response, tender_id):
+        tender = response.json()
+        self._write_json(tender_id, "tender.json", tender)
+
+        for document in tender.get("tenderDocuments") or []:
+            attachment = document.get("attachment")
+            if not attachment or attachment.get("isDeleted") or attachment.get("mimeType") == "text/html":
+                continue
+            yield scrapy.Request(
+                self.DOWNLOAD_URL.format(tender_id=tender_id, doc_id=document["objectId"]),
+                callback=self.parse_attachment,
+                cb_kwargs={
+                    "tender_id": tender_id,
+                    "doc_id": document["objectId"],
+                    "filename": attachment["fileName"],
+                    "expected_size": attachment.get("fileSize"),
+                },
+            )
+
+        yield scrapy.Request(
+            self.DOCUMENTS_URL.format(id=tender_id),
+            callback=self.parse_documents,
+            cb_kwargs={"tender_id": tender_id},
+        )
+
+        notice_number = tender.get("bzpNumber") or tender.get("noticeNumber")
+        if notice_number:
+            encoded = quote(notice_number, safe="")
+            yield scrapy.Request(
+                self.NOTICE_DETAILS_URL.format(n=encoded),
+                callback=self.parse_notice_meta,
+                cb_kwargs={"tender_id": tender_id, "encoded_notice_number": encoded},
+            )
+
+    def parse_documents(self, response, tender_id):
+        self._write_json(tender_id, "documents.json", response.json())
+
+    def parse_attachment(self, response, tender_id, doc_id, filename, expected_size):
+        path = self._tender_dir(tender_id) / "attachments" / UNSAFE_FILENAME_RE.sub("_", f"{doc_id}__{filename}")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(response.body)
+        if expected_size and len(response.body) != expected_size:
+            self.logger.warning(
+                "size mismatch for %s/%s: got %d bytes, expected %d",
+                tender_id,
+                doc_id,
+                len(response.body),
+                expected_size,
+            )
+
+    def parse_notice_meta(self, response, tender_id, encoded_notice_number):
+        self._write_json(tender_id, "notice_meta.json", response.json())
+        yield scrapy.Request(
+            self.NOTICE_HTML_URL.format(n=encoded_notice_number),
+            callback=self.parse_announcement,
+            cb_kwargs={"tender_id": tender_id},
+        )
+
+    def parse_announcement(self, response, tender_id):
+        path = self._tender_dir(tender_id)
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "announcement.html").write_text(response.text, encoding="utf-8")
+        parsed = parse_announcement(response.text)
+        parsed["raw_html_path"] = "announcement.html"
+        self._write_json(tender_id, "announcement.json", parsed)
+
+    def _tender_dir(self, tender_id):
+        return Path(self.settings["FILES_STORE"], self.name, self.crawl_directory, tender_id)
+
+    def _write_json(self, tender_id, filename, data):
+        path = self._tender_dir(tender_id)
+        path.mkdir(parents=True, exist_ok=True)
+        (path / filename).write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/generic_scrapy/spiders/poland.py
+++ b/generic_scrapy/spiders/poland.py
@@ -36,6 +36,8 @@ class Poland(BaseSpider):
     TENDER_URL = "https://ezamowienia.gov.pl/mp-readmodels/api/Search/GetTender?id={id}"
     DOCUMENTS_URL = "https://ezamowienia.gov.pl/mp-readmodels/api/Search/GetTenderDocuments?tenderId={id}"
     DOWNLOAD_URL = "https://ezamowienia.gov.pl/mp-readmodels/api/Tender/DownloadDocument/{tender_id}/{doc_id}"
+    # An mp-readmodels/api/Tender/GetTenderNoticeDetails endpoint returns the same shape as Board/GetNoticeDetails.
+    # Board is used here because its sibling GetNoticeHtmlBody has no mp-readmodels equivalent.
     NOTICE_DETAILS_URL = "https://ezamowienia.gov.pl/mo-board/api/v1/Board/GetNoticeDetails?noticeNumber={n}"
     NOTICE_HTML_URL = "https://ezamowienia.gov.pl/mo-board/api/v1/Board/GetNoticeHtmlBody?noticeNumber={n}"
 


### PR DESCRIPTION
Replace the mo-board/api/v1/notice flow (CSV of notices + contractors) with the mp-readmodels/api/Search/SearchTenders flow that lists procedures and exposes the attachments and structured tender data the notices API does not carry. Per tender, write tender.json, documents.json, notice_meta.json, announcement.html, announcement.json (parsed) and attachments/<docId>__<filename> under <FILES_STORE>/poland/<crawl_directory>/<tenderId>/.

Endpoint differences:
- iteration unit: notices (many per tender) → procedures (one per tender)
- attachments: not exposed → GetTender.tenderDocuments + DownloadDocument
- announcement HTML: inlined in htmlBody → separate Board/GetNoticeHtmlBody keyed by bzpNumber
- pagination: cursor (SearchAfter) → page number + X-Pagination header
- filter: NoticeType + date range → sort-only, walks the catalogue

Re-runs in the same crawl_directory skip tenders whose tender.json already exists. Removes the now-unused PolandNoticeFilter and PolandContractorFilter.

Known limitation: the new flow captures only the initial BZP notice for each tender, not subsequent award/update/performance notices.